### PR TITLE
Replace shortcut icon with icon

### DIFF
--- a/src/playground/index.ejs
+++ b/src/playground/index.ejs
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="google" value="notranslate">
-    <link rel="shortcut icon" href="static/favicon.svg">
+    <link rel="icon" href="static/favicon.svg">
     <title><%= htmlWebpackPlugin.options.title %></title>
     <% if (htmlWebpackPlugin.options.sentryConfig) { %>
         <!-- Sentry error logging to help with finding bugs -->


### PR DESCRIPTION
### Resolves

N/A

### Proposed Changes

Replaces "shortcut icon" with "icon"

### Reason for Changes

According to MDN, shortcut icon should no longer be used.

### Test Coverage

N/A

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
