### PR TITLE
Use glitchyscratch-i18n

### DIFF
--- a/src/reducers/locales.js
+++ b/src/reducers/locales.js
@@ -1,8 +1,8 @@
 import {addLocaleData} from 'react-intl';
 
-import {localeData} from 'scratch-l10n';
-import editorMessages from 'scratch-l10n/locales/editor-msgs';
-import {isRtl} from 'scratch-l10n';
+import {localeData} from 'glitchyscratch-i18n';
+import editorMessages from 'glitchyscratch-i18n/locales/editor-msgs';
+import {isRtl} from 'glitchyscratch-i18n';
 
 addLocaleData(localeData);
 


### PR DESCRIPTION
### Resolves

Partially Glitchy-Scratch/i18n#16

### Proposed Changes

Replaces Scratch's package with ``glitchyscratch-i18n``.

### Reason for Changes

See linked issue.

### Test Coverage

None

### Browser Coverage

N/A
