### PR TITLE
Make CI similar to deploy.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,13 @@ name: Node.JS CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [8.x, 10.x, 12.x]
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.JS ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install dependencies using NPM and run build files
+    - name: Checkout Code
+      uses: actions/checkout@v2
+    - name: Setup, Build and Install Dependencies using NPM
       run: npm install && npm run build
     - name: Run NPM test
       run: npm test


### PR DESCRIPTION
### Resolves

Resolves CI run failures.

### Proposed Changes

Makes ``ci.yml`` similar to ``deploy.yml``.

### Reason for Changes

CI runs are continuously failing currently. While site deployment is working, we should still fix it.

### Test Coverage

See GitHub Actions CI check result.
