### PR TITLE
Disable Google Analytics

### DIFF
--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,4 +1,4 @@
-import GoogleAnalytics from 'react-ga';
+/** import GoogleAnalytics from 'react-ga';
 
 import log from './log';
 
@@ -21,3 +21,4 @@ if (GA_ID) {
 }
 
 export default GoogleAnalytics;
+*/


### PR DESCRIPTION
### Resolves

Resolves #31.

### Proposed Changes

Disables Google Analytics.

### Reason for Changes

Google Analytics tracks users which we do not want.

#### Test Coverage
### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
